### PR TITLE
:memo: Add Create .gitmessage file to unify commit-messaage. #56

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,31 @@
+
+
+# ==== Format ====
+# :emoji: Subject #issue No.
+#
+# Commit body...
+
+# ==== Emojis ====
+# 📝 :memo:		ドキュメント作成
+# 🐛 :bug:		バグ修正
+# 👍 :+1:		機能改善
+# ✨ :sparkles:	部分的な機能追加
+# 🎉 :tada:		盛大に祝うべき大きな機能追加
+# ♻️  :recycle:	リファクタリング
+# 🚿 :shower:	不要な機能・使われなくなった機能の削除
+# 💚 :green_heart:	テストやCIの修正・改善
+# 👕 :shirt:	Lintエラーの修正やコードスタイルの修正
+# 🚀 :rocket:	パフォーマンス改善
+# 🆙 :up:		依存パッケージなどのアップデート
+# 🔒 :lock:		新機能の公開範囲の制限
+# 👮 :cop:		セキュリティ関連の改善
+
+# ==== The Seven Rules ====
+# 1. Separate subject from body with a blank line
+# 2. Limit the subject line to 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why vs. how
+#


### PR DESCRIPTION
# 概要
<!-- このプルリクエストの概要を書いてください -->
git commitのメッセージを統一するためのファイルを作成しました。

# 変更の概要
## 修正の背景
git commitのメッセージが個人により異なり、属人的になっているコミットメッセージを
統一化するため。

## 修正の内容
.gitmessageファイルを作成しました。

git commit -m "<コミットメッセージ>"と入力していたが、
commit messageを統一するために、git commit のみでvim を開いてコミットメッセージを記入してください。

# issues番号
#56 

# Refs (レビューにあたって参考にすべき情報）(Optional)
