### PR TITLE
Fix/request authority #35

### DIFF
--- a/MetaMera/Views/Profile/ProfileViewController.swift
+++ b/MetaMera/Views/Profile/ProfileViewController.swift
@@ -62,6 +62,7 @@ class ProfileViewController: UIViewController {
         
         
         imagePicker.allowsEditing = true
+        imagePicker.modalPresentationStyle = .fullScreen
         
         MapView.translatesAutoresizingMaskIntoConstraints = false
         // Do any additional setup after loading the view.
@@ -217,35 +218,48 @@ class ProfileViewController: UIViewController {
         //                        = .denied     : 拒否
         
         if authPhotoLibraryStatus == .limited {
-            // アラート表示
-            let title: String = "Failed to save image"
-            let message: String = "Allow this app to access Photos."
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-//            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            self.present(alert, animated: true, completion: nil)
             
-            // 設定アプリへ遷移
-            if let settingURL = URL(string: UIApplication.openSettingsURLString) {
-//                    self.dismiss(animated: true)
-                UIApplication.shared.canOpenURL(settingURL)
-                UIApplication.shared.open(settingURL, options: [:], completionHandler: nil)
+            //アラートの設定
+            let alert = UIAlertController(title: "Failed to save image", message: "Allow this app to access Photos.", preferredStyle: .alert)
+            let ok = UIAlertAction(title: "Enable photos access", style: .default) { (action) in
+                //設定を開く
+                if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.canOpenURL(settingURL)
+                    UIApplication.shared.open(settingURL, options: [:], completionHandler: nil)
+                }
             }
+            let cancel = UIAlertAction(title: "cancel", style: .cancel) { (acrion) in
+                self.dismiss(animated: true, completion: nil)
+            }
+            
+            //アラートの下にあるボタンを追加
+            alert.addAction(cancel)
+            alert.addAction(ok)
+            //アラートの表示
+            present(alert, animated: true, completion: nil)
             
             
         }
         if authPhotoLibraryStatus == .denied {
-            // アラート表示
-            let title: String = "Failed to save image"
-            let message: String = "Allow this app to access Photos."
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            self.present(alert, animated: true, completion: nil)
             
-            // 設定アプリへ遷移
-            if let settingURL = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.canOpenURL(settingURL)
-                UIApplication.shared.open(settingURL, options: [:], completionHandler: nil)
+            //アラートの設定
+            let alert = UIAlertController(title: "Failed to save image", message: "Allow this app to access Photos.", preferredStyle: .alert)
+            let ok = UIAlertAction(title: "Enable photos access", style: .default) { (action) in
+                //設定を開く
+                if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.canOpenURL(settingURL)
+                    UIApplication.shared.open(settingURL, options: [:], completionHandler: nil)
+                }
             }
+            let cancel = UIAlertAction(title: "cancel", style: .cancel) { (acrion) in
+                self.dismiss(animated: true, completion: nil)
+            }
+            
+            //アラートの下にあるボタンを追加
+            alert.addAction(cancel)
+            alert.addAction(ok)
+            //アラートの表示
+            present(alert, animated: true, completion: nil)
         }
         // fix/update_prof_image_#33 >>>
         if authPhotoLibraryStatus == .authorized {


### PR DESCRIPTION
# 概要
<!-- このプルリクエストの概要を書いてください -->
画像の権限が"全て許可"以外の時に設定から"全て許可"に変更するように促す動作を追加
# 変更の概要
## 修正の背景
一部許可だとよくわからない動作が入ってしまうので全て許可にさせたい
## 修正の内容
アラートを表示させてそこから設定へ移動させるようにした

# issues番号
#35 
# 動作確認
<!-- どのような環境で動作確認したのか列挙してください -->
- iPhone 12 Pro