### PR TITLE
アップデートさせるかどうかをRemote Config側で設定できるようになりました。

### DIFF
--- a/MetaMera/Views/Top/TopViewController.swift
+++ b/MetaMera/Views/Top/TopViewController.swift
@@ -257,12 +257,18 @@ class TopViewController: UIViewController {
         )
     }
     
+    /// 最新のバージョンか確認します。
+    /// - Parameter completion: アップデートが必要ならtrueを返します。
     func updateCheck(completion: ((Bool) -> Void)? = nil){
         let localVersionString = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
         RemoteConfigClient.shared.fetchUpdateInfoConfig(
             succeeded: { [weak self] config in
-                self?.newest = localVersionString != config.current_version
-                completion?(localVersionString != config.current_version)
+                if config.updateInfo {
+                    self?.newest = localVersionString != config.current_version
+                    completion?(localVersionString != config.current_version)
+                }else{
+                    completion?(false)
+                }
             },failed: { [weak self] errorMessage in
                 self?.newest = false
                 completion?(true)


### PR DESCRIPTION
# 概要
<!-- このプルリクエストの概要を書いてください -->
今までバージョンが古かったらアップデートするしかなかったが、開発時はバージョンに差異が出て当たり前で不便だった為Remote Config側で設定できるようになった。

# 動作確認
<!-- どのような環境で動作確認したのか列挙してください -->
- iPhone 12 Pro
